### PR TITLE
Fix code scanning alert no. 9: Incomplete string escaping or encoding

### DIFF
--- a/lib/pdffont.js
+++ b/lib/pdffont.js
@@ -362,15 +362,15 @@ export default class PDFFont {
 
    flashEncode(str) {
       let retVal = encodeURIComponent(str);
-      retVal = retVal.replace('%C2%96', '-');
-      retVal = retVal.replace('%C2%91', '%27');
-      retVal = retVal.replace('%C2%92', '%27');
-      retVal = retVal.replace('%C2%82', '%27');
-      retVal = retVal.replace('%C2%93', '%22');
-      retVal = retVal.replace('%C2%94', '%22');
-      retVal = retVal.replace('%C2%84', '%22');
-      retVal = retVal.replace('%C2%8B', '%C2%AB');
-      retVal = retVal.replace('%C2%9B', '%C2%BB');
+      retVal = retVal.replace(/%C2%96/g, '-');
+      retVal = retVal.replace(/%C2%91/g, '%27');
+      retVal = retVal.replace(/%C2%92/g, '%27');
+      retVal = retVal.replace(/%C2%82/g, '%27');
+      retVal = retVal.replace(/%C2%93/g, '%22');
+      retVal = retVal.replace(/%C2%94/g, '%22');
+      retVal = retVal.replace(/%C2%84/g, '%22');
+      retVal = retVal.replace(/%C2%8B/g, '%C2%AB');
+      retVal = retVal.replace(/%C2%9B/g, '%C2%BB');
 
       return retVal;
    }


### PR DESCRIPTION
Fixes [https://github.com/universalbit-dev/pdf2json/security/code-scanning/9](https://github.com/universalbit-dev/pdf2json/security/code-scanning/9)

To fix the problem, we need to ensure that all occurrences of the specified substrings are replaced in the `flashEncode` method. This can be achieved by using regular expressions with the `g` flag instead of string literals in the `replace` method. This change will ensure that all instances of the substrings are replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
